### PR TITLE
move file system to node crypto

### DIFF
--- a/examples/createClient.js
+++ b/examples/createClient.js
@@ -30,8 +30,8 @@ const writeFile = async client => {
 }
 
 const readFile = async client => {
-  const recordID = '5d98c2f4-22e8-484a-be8d-94ad50940ae8'
-  const destFile = 'jane.txt'
+  const recordID = 'cc6e324d-91d0-4328-a536-3402ae6d6f24'
+  const destFile = 'diana.png'
   try {
     let decryptedFile = await client.readLargeFile(
       recordID,

--- a/lib/SodiumCrypto.js
+++ b/lib/SodiumCrypto.js
@@ -433,7 +433,9 @@ export default class SodiumCrypto extends Crypto {
     }
     const checkSum = hash.base64('')
 
-    return [encryptedFileName, checkSum, encryptedLength]
+    let encryptedFile = fs.createReadStream(encryptedFileName)
+
+    return [encryptedFile, checkSum, encryptedLength]
   }
 
   async decryptFile(destFileName, ak, sourceFileName) {


### PR DESCRIPTION
- creates a read stream in encryptLargeFile instead of in client-interface. returns a stream instead of a file name
- still needed: implement something similar in decryptFile so that the file system can be taken out of client interface completely. possible solutions for this include downloading the file from the aws server without a write stream or parsing the file into something that is also accepted in the browser. there does not appear to be a straightforward way to do this yet.